### PR TITLE
Bump gtk version so tauri v2 can be built

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/clipboard-files/"
 license = "MIT OR Apache-2.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-gtk = "0.15"
+gtk = "0.18"
 urlencoding = "2.1.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]


### PR DESCRIPTION
With the current version of gtk there are unresolvable dependency conflicts when building tauri v2 apps using this library. This PR solves the problem. Currently I cannot check that the crate builds successfully on linux targets. I'd be grateful if someone could help with that.